### PR TITLE
Fix indentation in gcloud error checking

### DIFF
--- a/pydocker/utils.py
+++ b/pydocker/utils.py
@@ -143,9 +143,9 @@ class LocalContainer:
         import google.auth
 
         _, project = google.auth.default()
-            if project is None:
-                raise ValueError("google.auth.default() could not determine cloud project on laptop")
-        
+        if project is None:
+            raise ValueError("google.auth.default() could not determine cloud project on laptop")
+
         self.environment["GOOGLE_CLOUD_PROJECT"] = project
         self.environment[
             "GOOGLE_APPLICATION_CREDENTIALS"


### PR DESCRIPTION
Looks like there was a typo introducing extra indentation.