### PR TITLE
Skip missing private keys

### DIFF
--- a/pydocker/__init__.py
+++ b/pydocker/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Damien Ramunno-Johnson"""
 __email__ = 'damien@squareup.com'
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 from pydocker import ssh, utils # NOQA

--- a/pydocker/utils.py
+++ b/pydocker/utils.py
@@ -52,10 +52,13 @@ def setup_machine():
         h.write(conents)
     keys = [splitext(x)[0] for x in glob.glob(os.path.join(ssh_path, "*.pub"))]
     for key in keys:
-        logger.info("Adding key {}".format(key))
-        dest = os.path.join(cloud_path, basename(key))
-        if os.path.lexists(dest) is False:
-            bash("cp {} {}".format(key, dest))
+        if not os.path.isfile(key):
+            logger.warning("No private key for {}, skipping".format(key))
+        else:
+            logger.info("Adding key {}".format(key))
+            dest = os.path.join(cloud_path, basename(key))
+            if os.path.lexists(dest) is False:
+                bash("cp {} {}".format(key, dest))
 
 
 def start_ssh():

--- a/pydocker/utils.py
+++ b/pydocker/utils.py
@@ -50,7 +50,11 @@ def setup_machine():
         h.write(config)
     with open(config_path, "a") as h:
         h.write(conents)
-    keys = [splitext(x)[0] for x in glob.glob(os.path.join(ssh_path, "*.pub"))]
+    keys = [
+        splitext(x)[0]
+        for x in glob.glob(os.path.join(ssh_path, "*.pub"))
+        if not x.endswith("-cert.pub")  # filter out signed keys
+    ]
     for key in keys:
         if not os.path.isfile(key):
             logger.warning("No private key for {}, skipping".format(key))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 
@@ -14,4 +14,3 @@ replace = __version__ = '{new_version}'
 [flake8]
 max-line-length = 100
 exclude = docs
-

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {
 
 setup(
     name='sq-pydocker',
-    version='0.4.0',
+    version='0.4.1',
     description='Python package to make it easier to manage docker containers',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
If for some reason a private key doesn't exist using the standard key/key.pub naming convention, issue a warning but still continue setup.